### PR TITLE
Canonicalize several details in preparation for upstreaming into vim

### DIFF
--- a/ftplugin/vroom.vim
+++ b/ftplugin/vroom.vim
@@ -7,16 +7,14 @@ if exists('b:did_ftplugin')
 endif
 let b:did_ftplugin = 1
 
-let b:undo_ftplugin = 'setlocal formatoptions< tabstop< shiftwidth<' .
-    \ ' softtabstop< expandtab< autoindent< iskeyword< comments< commentstring<'
+let b:undo_ftplugin = 'setlocal formatoptions< shiftwidth< softtabstop<' .
+    \ ' expandtab< iskeyword< comments< commentstring<'
 
 setlocal formatoptions-=t
 
-setlocal tabstop=2
 setlocal shiftwidth=2
 setlocal softtabstop=2
 setlocal expandtab
-setlocal autoindent
 
 " To allow tag lookup and autocomplete for whole autoload functions, '#' must be
 " a keyword character. This also conforms to the behavior of ftplugin/vim.vim.

--- a/ftplugin/vroom.vim
+++ b/ftplugin/vroom.vim
@@ -2,16 +2,26 @@
 " @section Introduction, intro
 " Syntax and core settings for the vroom filetype.
 
+" Vim filetype plugin file
+" Language:	Vroom (vim testing and executable documentation)
+" Maintainer:	David Barnett (https://github.com/google/vim-ft.vroom)
+" Last Change:	2014 Jul 7
+
 if exists('b:did_ftplugin')
   finish
 endif
 let b:did_ftplugin = 1
+
+let s:cpo_save = &cpo
+set cpo-=C
+
 
 let b:undo_ftplugin = 'setlocal formatoptions< shiftwidth< softtabstop<' .
     \ ' expandtab< iskeyword< comments< commentstring<'
 
 setlocal formatoptions-=t
 
+" The vroom interpreter doesn't accept anything but 2-space indent.
 setlocal shiftwidth=2
 setlocal softtabstop=2
 setlocal expandtab
@@ -23,3 +33,7 @@ setlocal iskeyword+=#
 " Vroom files have no comments (text is inert documentation unless indented).
 setlocal comments=
 setlocal commentstring=
+
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/indent/vroom.vim
+++ b/indent/vroom.vim
@@ -1,8 +1,21 @@
+" Vim indent file
+" Language:	Vroom (vim testing and executable documentation)
+" Maintainer:	David Barnett (https://github.com/google/vim-ft.vroom)
+" Last Change:	2014 Jul 7
+
 if exists('b:did_indent')
   finish
 endif
 let b:did_indent = 1
 
+let s:cpo_save = &cpo
+set cpo-=C
+
+
 let b:undo_indent = 'setlocal autoindent<'
 
 setlocal autoindent
+
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/indent/vroom.vim
+++ b/indent/vroom.vim
@@ -1,0 +1,8 @@
+if exists('b:did_indent')
+  finish
+endif
+let b:did_indent = 1
+
+let b:undo_indent = 'setlocal autoindent<'
+
+setlocal autoindent

--- a/syntax/vroom.vim
+++ b/syntax/vroom.vim
@@ -1,3 +1,20 @@
+" Vim syntax file
+" Language:	Vroom (vim testing and executable documentation)
+" Maintainer:	David Barnett (https://github.com/google/vim-ft.vroom)
+" Last Change:	2014 July 7
+
+" For version 5.x: Clear all syntax items
+" For version 6.x: Quit when a syntax file was already loaded
+if version < 600
+  syntax clear
+elseif exists('b:current_syntax')
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo-=C
+
+
 syn include @vroomVim syntax/vim.vim
 syn include @vroomShell syntax/sh.vim
 
@@ -88,3 +105,9 @@ highlight default link vroomDelay Type
 highlight default link vroomStrictness vroomMode
 highlight default link vroomChannel vroomMode
 highlight default link vroomBind vroomMode
+
+let b:current_syntax = 'vroom'
+
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/syntax/vroom.vim
+++ b/syntax/vroom.vim
@@ -3,9 +3,9 @@
 " Maintainer:	David Barnett (https://github.com/google/vim-ft.vroom)
 " Last Change:	2014 July 7
 
-" For version 5.x: Clear all syntax items
-" For version 6.x: Quit when a syntax file was already loaded
-if version < 600
+" For version 5.x: Clear all syntax items.
+" For version 6.x and later: Quit when a syntax file was already loaded.
+if v:version < 600
   syntax clear
 elseif exists('b:current_syntax')
   finish


### PR DESCRIPTION
Fixes several discrepancies from other built-in vim files to make these files more upstreamable:
- Move autoindent to indent/vroom.vim so it isn't enabled in the case of `:filetype indent off`.
- Stop setting tabstop. Vim maintainers like it to be 8 everywhere and it's not worth arguing over since we expand all tabs anyway.
- Enable line wrapping explicitly with `:set cpo-=C` to support vi-compatible-mode users.
- Set `b:current_syntax` and add missing source guard.
- Add standard boilerplate comments documenting various files.
