### PR TITLE
Add top-level vroomText syntax match with @Spell

### DIFF
--- a/syntax/vroom.vim
+++ b/syntax/vroom.vim
@@ -18,6 +18,8 @@ set cpo-=C
 syn include @vroomVim syntax/vim.vim
 syn include @vroomShell syntax/sh.vim
 
+syntax match vroomText '\m^\S.*' containedin=NONE contains=@Spell
+
 syntax region vroomAction
     \ matchgroup=vroomOutput
     \ start='\m^  ' end='\m$' keepend


### PR DESCRIPTION
Add a top-level syntax group for vroom text (a.k.a. comments) with spell checking enabled.

Fixes #4.
